### PR TITLE
Fix package exports

### DIFF
--- a/descriptors/package.json
+++ b/descriptors/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/descriptors.js",
+  "module": "../dist/descriptors.cjs",
+  "types": "../dist/descriptors.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"dist",
 		"src/types.ts"
 	],
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		"./package.json": "./package.json",
 		"./src/*": "./src/*",
@@ -21,8 +23,8 @@
 			"require": "./dist/descriptors.cjs"
 		},
 		"./types": {
-			"import": "./types.ts",
-			"require": "./types.ts"
+			"import": "./src/types.ts",
+			"require": "./src/types.ts"
 		}
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -9,22 +9,23 @@
 		"dist",
 		"src/types.ts"
 	],
-	"main": "dist/index.cjs",
-	"types": "dist/index.d.ts",
+	"main": "./dist/index.cjs",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		"./package.json": "./package.json",
 		"./src/*": "./src/*",
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		},
 		"./descriptors": {
+			"types": "./dist/descriptors.d.ts",
 			"import": "./dist/descriptors.js",
 			"require": "./dist/descriptors.cjs"
 		},
 		"./types": {
-			"import": "./src/types.ts",
-			"require": "./src/types.ts"
+			"types": "./src/types.ts"
 		}
 	},
 	"repository": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.js",
+  "types": "../src/types.ts"
+}


### PR DESCRIPTION
This PR fixes the following entrypoints to Thyseus:
- `thyseus/types`, which exports Thyseus types declared in the global scope
- `thyseus/descriptors`, which exports built-in system parameter descriptors

These entrypoints were originally defined within the package.json's `exports` field, but in order for `exports` to work with TypeScript, the package consumer set their tsconfig's `--moduleResolution` to `node16` or `nodenext`, which is not ideal for obvious reasons. See [the original issue](https://github.com/microsoft/TypeScript/issues/33079) (locked for bad behavior) and the [follow-up](https://github.com/microsoft/TypeScript/issues/50794) issue that describes the `moduleResolution` workaround outlined above.

This PR instead adds two new sub-packages (subdirectories) each with their own package.json that point to their exports via `main`/`module`/`types` fields.