### PR TITLE
[entities] [table] [world] Rewrite Entities, empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
     -   Removed `registerThreadChannel()`
 -   `World`
     -   Removed `update()`
+    -   Renamed `archetypes` to `tables`
+-   `Table`
+    -   Instances are no longer constructed on threads
+    -   Renamed bitfield to archetype
+    -   `grow()` accepts a `newSize` parameter, to individual tables can grow
+        differently.
 -   `ThreadGroup`
     -   Changed send to `send(channelName: string, data: SendableType)`
 -   Removed `definePlugin()`
@@ -24,7 +30,6 @@
 -   The `Entity` component will throw an error if trying to construct it without
     `world.commands` and `world.entities`
 -   Renamed `table.size` to `table.length`
--   `Table`s are no longer constructed on threads
 
 ### ✨ Features
 

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -81,7 +81,7 @@ export class Commands {
 	 * @returns `EntityCommands`, which can add/remove components from an entity.
 	 */
 	spawn(): EntityCommands {
-		const entityId = this.#entities.spawn();
+		const entityId = this.#entities.getId();
 		const dataStart = this.#pushComponentCommand(
 			ADD_COMPONENT_COMMAND,
 			entityId,

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -329,7 +329,7 @@ if (import.meta.vitest) {
 				continue;
 			}
 			const componentId = memory.views.u16[(dataStart + 8) >> 1];
-			val ??= world.entities.getBitset(entityId);
+			val ??= world.entities.getArchetype(entityId);
 			entityDestinations.set(
 				entityId,
 				type === ADD_COMPONENT_COMMAND

--- a/src/commands/applyCommands.ts
+++ b/src/commands/applyCommands.ts
@@ -40,8 +40,8 @@ export function applyCommands(
 	}
 
 	// Move entities to their final destination
-	for (const [entityId, tableId] of entityDestinations) {
-		world.moveEntity(entityId, tableId);
+	for (const [entityId, archetype] of entityDestinations) {
+		world.moveEntity(entityId, archetype);
 	}
 
 	// Handle data insertion from adds
@@ -50,7 +50,7 @@ export function applyCommands(
 			continue;
 		}
 		const entityId = memory.views.u64[dataStart >> 3];
-		const tableId = entities.getTableIndex(entityId);
+		const tableId = entities.getTableId(entityId);
 		if (tableId === 0) {
 			continue;
 		}
@@ -145,10 +145,13 @@ if (import.meta.vitest) {
 		myWorld.commands.spawn().addType(CompA).add(new CompD(1, 2));
 
 		applyCommands(myWorld, new Map());
-		const archetypeD = myWorld.tables[2];
+		const archetypeD = myWorld.tables[1];
 		const testComp = new CompD();
 
-		testComp.__$$b = archetypeD.getColumn(CompD)!;
+		const column =
+			memory.views.u32[archetypeD.getColumnPointer(CompD) >> 2];
+
+		testComp.__$$b = column;
 		expect(archetypeD.length).toBe(1);
 		expect(testComp.x).toBe(1);
 		expect(testComp.y).toBe(2);

--- a/src/queries/Query.ts
+++ b/src/queries/Query.ts
@@ -142,7 +142,7 @@ export class Query<A extends Accessors, F extends Filter = []> {
 
 	testAdd(table: Table): void {
 		const { u32 } = memory.views;
-		if (this.#test(table.bitfield)) {
+		if (this.#test(table.archetype)) {
 			if (this.#size === this.#capacity) {
 				// Grow for 8 tables at a time
 				const additionalSize = 8 * (this.#components.length + 1);
@@ -212,23 +212,23 @@ if (import.meta.vitest) {
 		const world = await createWorld(ZST);
 		const entity1 = world.entities.spawn();
 		world.moveEntity(entity1, 0b0001n);
-		const table = world.archetypes[2];
+		const table = world.tables[2];
 		const query1 = new Query([0b0001n], [0b0000n], false, [], world);
 		expect(query1.length).toBe(0);
 		query1.testAdd(table);
 		expect(query1.length).toBe(1);
 
-		table.bitfield = 0b0010n; // No longer matches
+		table.archetype = 0b0010n; // No longer matches
 		query1.testAdd(table);
 		expect(query1.length).toBe(1);
 
 		const query2 = new Query([0b0100n], [0b1011n], false, [], world);
 		expect(query2.length).toBe(0);
-		table.bitfield = 0b0110n;
+		table.archetype = 0b0110n;
 		query2.testAdd(table);
 		expect(query2.length).toBe(0);
 
-		table.bitfield = 0b0100n;
+		table.archetype = 0b0100n;
 		query2.testAdd(table);
 		expect(query2.length).toBe(1);
 
@@ -240,26 +240,26 @@ if (import.meta.vitest) {
 			world,
 		);
 		expect(query3.length).toBe(0);
-		table.bitfield = 0b0001n;
+		table.archetype = 0b0001n;
 		query3.testAdd(table); // Passes 1
 		expect(query3.length).toBe(1);
-		table.bitfield = 0b0010n;
+		table.archetype = 0b0010n;
 		query3.testAdd(table); // Passes 2
 		expect(query3.length).toBe(2);
-		table.bitfield = 0b0100n;
+		table.archetype = 0b0100n;
 		query3.testAdd(table); // Passes 3
 		expect(query3.length).toBe(3);
-		table.bitfield = 0b0110n;
+		table.archetype = 0b0110n;
 		query3.testAdd(table); // Fails 1 With, 2/3 without
 		expect(query3.length).toBe(3);
-		table.bitfield = 0b1001n;
+		table.archetype = 0b1001n;
 		query3.testAdd(table); // Fails 1 Without, 2/3 With
 		expect(query3.length).toBe(3);
 	});
 
 	describe('iteration', () => {
 		const createTable = (world: World, ...components: Struct[]) =>
-			Table.create(world, components, 0n, 0);
+			new Table(world, components, 0n, 0);
 
 		class Vec3 {
 			static size = 24;
@@ -314,8 +314,8 @@ if (import.meta.vitest) {
 			const vecTable = createTable(world, Entity, Vec3);
 			const noVecTable = createTable(world, Entity);
 
-			query.testAdd({ ...noVecTable, bitfield: 0n } as any);
-			query.testAdd({ ...vecTable, bitfield: 0n } as any);
+			query.testAdd({ ...noVecTable, archetype: 0n } as any);
+			query.testAdd({ ...vecTable, archetype: 0n } as any);
 			expect(query.length).toBe(0);
 			for (let i = 0; i < 10; i++) {
 				spawnIntoTable(i, i < 5 ? noVecTable : vecTable);
@@ -341,8 +341,8 @@ if (import.meta.vitest) {
 			for (let i = 0; i < 10; i++) {
 				world.moveEntity(world.entities.spawn(), 0b11n);
 			}
-			const table = world.archetypes[2];
-			table.bitfield = 0n;
+			const table = world.tables[2];
+			table.archetype = 0n;
 			expect(query.length).toBe(0);
 			query.testAdd(table);
 			expect(query.length).toBe(10);
@@ -364,10 +364,10 @@ if (import.meta.vitest) {
 				world,
 			);
 			world.moveEntity(world.entities.spawn(), 0b11n);
-			const table = world.archetypes[2];
+			const table = world.tables[2];
 			expect(query.length).toBe(0);
 
-			table.bitfield = 0n;
+			table.archetype = 0n;
 			query.testAdd(table);
 			expect(query.length).toBe(1);
 			for (let i = 1; i < 8; i++) {
@@ -409,8 +409,8 @@ if (import.meta.vitest) {
 				world,
 			);
 			world.moveEntity(world.entities.spawn(), 0b111n);
-			const table = world.archetypes[2];
-			table.bitfield = 0n;
+			const table = world.tables[2];
+			table.archetype = 0n;
 
 			expect(queryTuple.length).toBe(0);
 			expect(querySolo.length).toBe(0);

--- a/src/storage/Table.ts
+++ b/src/storage/Table.ts
@@ -1,25 +1,19 @@
 import { memory } from '../utils/memory';
 import { Entity } from './Entity';
-import type { World } from '../world';
 import type { Struct } from '../struct';
 
 export class Table {
-	static createEmpty(world: World): Table {
-		return new this(world, [], 0n, 1);
+	static createEmpty(): Table {
+		const table = new this([], 0n, 0);
+		table.length = 2 ** 32 - 1;
+		return table;
 	}
 
-	#world: World;
 	#components: Struct[];
 	#pointer: number; // [size, capacity, ...columnPointers]
 	archetype: bigint;
 	#id: number;
-	constructor(
-		world: World,
-		components: Struct[],
-		archetype: bigint,
-		id: number,
-	) {
-		this.#world = world;
+	constructor(components: Struct[], archetype: bigint, id: number) {
 		this.#components = components.filter(component => component.size! > 0);
 		this.#pointer = memory.alloc(8 * (2 + this.#components.length));
 		this.archetype = archetype;
@@ -39,11 +33,6 @@ export class Table {
 		memory.views.u32[this.#pointer >> 2] = value;
 	}
 
-	getColumn(componentType: Struct): number {
-		return memory.views.u32[
-			(this.#pointer >> 2) + 2 + this.#components.indexOf(componentType)
-		];
-	}
 	hasColumn(componentType: Struct): boolean {
 		return this.#components.includes(componentType);
 	}
@@ -62,25 +51,22 @@ export class Table {
 		}
 	}
 
-	move(index: number, targetTable: Table): bigint {
-		if (targetTable.capacity === targetTable.length) {
-			targetTable.grow();
-		}
+	move(index: number, targetTable: Table): null | bigint {
 		const { u32, u64 } = memory.views;
 		if (this.#components.length === 0) {
 			targetTable.length++;
-			return BigInt(index);
+			return null;
 		}
-		const ptr = this.getColumn(Entity);
+		const ptr = this.#getColumn(Entity);
 		const lastEntity = u64[(ptr >> 3) + this.length];
 		for (const component of this.#components) {
 			const componentPointer =
-				this.getColumn(component) + index * component.size!;
+				this.#getColumn(component) + index * component.size!;
 			if (targetTable.hasColumn(component)) {
 				memory.copy(
 					componentPointer,
 					component.size!,
-					targetTable.getColumn(component) +
+					targetTable.#getColumn(component) +
 						targetTable.length * component.size!,
 				);
 			} else {
@@ -94,9 +80,8 @@ export class Table {
 		return lastEntity;
 	}
 
-	grow(): void {
-		memory.views.u32[(this.#pointer >> 2) + 1] =
-			this.#world.config.getNewTableSize(this.capacity);
+	grow(newCapacity: number): void {
+		memory.views.u32[(this.#pointer >> 2) + 1] = newCapacity;
 		let i = 8;
 		for (const component of this.#components) {
 			memory.reallocAt(
@@ -116,7 +101,7 @@ export class Table {
 			memory.copy(
 				copyFrom,
 				componentType.size!,
-				this.getColumn(componentType) + row * componentType.size!,
+				this.#getColumn(componentType) + row * componentType.size!,
 			);
 		}
 	}
@@ -130,6 +115,11 @@ export class Table {
 	getTableSizePointer(): number {
 		return this.#pointer;
 	}
+	#getColumn(componentType: Struct): number {
+		return memory.views.u32[
+			(this.#pointer >> 2) + 2 + this.#components.indexOf(componentType)
+		];
+	}
 }
 
 /*---------*\
@@ -140,7 +130,10 @@ if (import.meta.vitest) {
 	const { World } = await import('../world');
 	const { struct } = await import('../struct');
 
-	beforeEach(() => memory.UNSAFE_CLEAR_ALL());
+	beforeEach(() => {
+		memory.init(10_000);
+		return () => memory.UNSAFE_CLEAR_ALL();
+	});
 
 	@struct
 	class Vec3 {
@@ -165,39 +158,45 @@ if (import.meta.vitest) {
 			.registerComponent(Vec3)
 			.registerComponent(StringComponent)
 			.build();
-	const createTable = (world: World, ...components: Struct[]) =>
-		new Table(world, components, 0n, 0);
+	const createTable = (...components: Struct[]) =>
+		new Table(components, 0n, 0);
+	const getColumn = (table: Table, column: Struct) =>
+		memory.views.u32[table.getColumnPointer(column) >> 2];
 	const spawnIntoTable = (eid: number, targetTable: Table) => {
 		if (targetTable.capacity === targetTable.length) {
-			targetTable.grow();
+			targetTable.grow(targetTable.capacity * 2 || 8);
 		}
-		memory.views.u64[
-			(targetTable.getColumn(Entity) + targetTable.length * 8) >> 3
-		] = BigInt(eid);
+		const column = getColumn(targetTable, Entity);
+		memory.views.u64[(column + targetTable.length * 8) >> 3] = BigInt(eid);
 		targetTable.length++;
 	};
 
 	it('adds an element', async () => {
 		const world = await createWorld();
-		const table = createTable(world, Entity);
+		const table = createTable(Entity);
 		expect(table.length).toBe(0);
-		expect(table.capacity).toBe(8);
+		expect(table.capacity).toBe(0);
+
 		spawnIntoTable(0, table);
-		const entity = new Entity(world.commands, world.entities);
-		(entity as any).__$$b = table.getColumn(Entity);
-		expect(entity.id).toBe(0n);
 		expect(table.length).toBe(1);
+		expect(table.capacity).toBe(8);
+
+		const entity = new Entity(world.commands, world.entities);
+		(entity as any).__$$b = getColumn(table, Entity);
+		expect(entity.id).toBe(0n);
+
 		spawnIntoTable(3, table);
 		expect(entity.id).toBe(0n);
-		(entity as any).__$$b += 8;
+
+		(entity as any).__$$b += Entity.size;
 		expect(entity.id).toBe(3n);
 		expect(table.length).toBe(2);
 	});
 
 	it('moves elements from one table to another', async () => {
 		const world = await createWorld();
-		const fromTable = createTable(world, Entity, Vec3);
-		const toTable = createTable(world, Entity, Vec3);
+		const fromTable = createTable(Entity, Vec3);
+		const toTable = createTable(Entity, Vec3);
 
 		spawnIntoTable(3, fromTable);
 		spawnIntoTable(1, fromTable);
@@ -207,11 +206,11 @@ if (import.meta.vitest) {
 
 		expect(fromTable.length).toBe(2);
 		expect(toTable.length).toBe(1);
-		(ent as any).__$$b = fromTable.getColumn(Entity);
+		(ent as any).__$$b = getColumn(fromTable, Entity);
 		expect(ent.id).toBe(3n);
 
 		const from = new Vec3();
-		from.__$$b = fromTable.getColumn(Vec3);
+		from.__$$b = getColumn(fromTable, Vec3);
 		from.x = 1;
 		from.y = 2;
 		from.z = 3;
@@ -221,7 +220,7 @@ if (import.meta.vitest) {
 		from.z = 9;
 
 		const to = new Vec3();
-		to.__$$b = toTable.getColumn(Vec3)!;
+		to.__$$b = getColumn(toTable, Vec3)!;
 		expect(to.x).toBe(0);
 		expect(to.y).toBe(0);
 		expect(to.z).toBe(0);
@@ -236,7 +235,7 @@ if (import.meta.vitest) {
 		expect(to.y).toBe(2);
 		expect(to.z).toBe(3);
 
-		from.__$$b = fromTable.getColumn(Vec3);
+		from.__$$b = getColumn(fromTable, Vec3);
 		expect(from.x).toBe(7);
 		expect(from.y).toBe(8);
 		expect(from.z).toBe(9);
@@ -245,19 +244,20 @@ if (import.meta.vitest) {
 
 	it('deletes elements, swaps in last elements', async () => {
 		const world = await createWorld();
-		const table = createTable(world, Entity, Vec3);
-		const entPtr = table.getColumn(Entity);
-		const vecPtr = table.getColumn(Vec3);
-		const vec = new Vec3();
-		vec.__$$b = vecPtr;
-		const ent = new Entity(world.commands, world.entities);
-		(ent as any).__$$b = entPtr;
+		const table = createTable(Entity, Vec3);
 
 		spawnIntoTable(1, table);
 		spawnIntoTable(2, table);
 		spawnIntoTable(3, table);
 		spawnIntoTable(4, table);
 		expect(table.length).toBe(4);
+
+		const entPtr = getColumn(table, Entity);
+		const vecPtr = getColumn(table, Vec3);
+		const vec = new Vec3();
+		vec.__$$b = vecPtr;
+		const ent = new Entity(world.commands, world.entities);
+		(ent as any).__$$b = entPtr;
 
 		vec.x = 1;
 		vec.y = 2;
@@ -300,27 +300,27 @@ if (import.meta.vitest) {
 
 	it('grows correctly', async () => {
 		const world = await createWorld();
-		const table = createTable(world, Entity);
-
-		const ent = new Entity(world.commands, world.entities);
-		(ent as any).__$$b = table.getColumn(Entity);
+		const table = createTable(Entity);
 
 		spawnIntoTable(1, table);
-
-		expect(table.capacity).toBe(8);
 		expect(table.length).toBe(1);
-		expect(ent.id).toBe(1n);
-		table.grow();
-		(ent as any).__$$b = table.getColumn(Entity);
+		expect(table.capacity).toBe(8);
+
+		const entity = new Entity(world.commands, world.entities);
+		(entity as any).__$$b = getColumn(table, Entity);
+		expect(entity.id).toBe(1n);
+
+		table.grow(table.capacity * 2 || 8);
+		(entity as any).__$$b = getColumn(table, Entity);
 		expect(table.capacity).toBe(16);
-		expect(ent.id).toBe(1n);
+		expect(entity.id).toBe(1n);
 	});
 
 	// v0.6 changelog bugfix
 	it('backfills elements for ALL stores', async () => {
 		const world = await createWorld();
-		const fromTable = createTable(world, Entity, Vec3);
-		const toTable = createTable(world, Entity);
+		const fromTable = createTable(Entity, Vec3);
+		const toTable = createTable(Entity);
 		const ent = new Entity(world.commands, world.entities);
 
 		spawnIntoTable(3, fromTable);
@@ -329,11 +329,11 @@ if (import.meta.vitest) {
 
 		expect(fromTable.length).toBe(2);
 		expect(toTable.length).toBe(1);
-		(ent as any).__$$b = fromTable.getColumn(Entity);
+		(ent as any).__$$b = getColumn(fromTable, Entity);
 		expect(ent.id).toBe(3n);
 
 		const from = new Vec3();
-		from.__$$b = fromTable.getColumn(Vec3)!;
+		from.__$$b = getColumn(fromTable, Vec3)!;
 		from.x = 1;
 		from.y = 2;
 		from.z = 3;
@@ -344,11 +344,11 @@ if (import.meta.vitest) {
 
 		fromTable.move(0, toTable);
 
-		(ent as any).__$$b = toTable.getColumn(Entity)! + Entity.size!;
+		(ent as any).__$$b = getColumn(toTable, Entity)! + Entity.size!;
 		expect(ent.id).toBe(3n);
 
-		from.__$$b = fromTable.getColumn(Vec3);
-		(ent as any).__$$b = fromTable.getColumn(Entity);
+		from.__$$b = getColumn(fromTable, Vec3);
+		(ent as any).__$$b = getColumn(fromTable, Entity);
 		expect(ent.id).toBe(1n);
 		expect(from.x).toBe(7);
 		expect(from.y).toBe(8);
@@ -361,21 +361,19 @@ if (import.meta.vitest) {
 			static size = 0;
 			static alignment = 1;
 		}
-		const world = await createWorld();
-		const table = createTable(world, Entity, Vec3, ZST);
+		const table = createTable(Entity, Vec3, ZST);
 		expect(table.hasColumn(ZST)).toBe(false);
 	});
 
 	it('move frees pointers if the target table does not have the pointer column', async () => {
-		const world = await createWorld();
 		const freeSpy = vi.spyOn(memory, 'free');
-		const initialTable = createTable(world, Entity, StringComponent);
-		const targetTable = createTable(world, Entity);
+		const initialTable = createTable(Entity, StringComponent);
+		const targetTable = createTable(Entity);
 
 		spawnIntoTable(0, initialTable);
 
 		const pointer = memory.alloc(8);
-		memory.views.u32[(initialTable.getColumn(StringComponent) + 8) >> 2] =
+		memory.views.u32[(getColumn(initialTable, StringComponent) + 8) >> 2] =
 			pointer;
 
 		expect(freeSpy).not.toHaveBeenCalled();

--- a/src/storage/Vec.ts
+++ b/src/storage/Vec.ts
@@ -1,0 +1,52 @@
+import { memory } from '../utils/memory';
+
+/**
+ * A `Vec<u32>`.
+ */
+export class Vec {
+	static size = 12;
+	static alignment = 4;
+
+	static fromPointer(pointer: number) {
+		return new this(pointer >> 2);
+	}
+	static new() {
+		return new this(memory.alloc(this.size) >> 2);
+	}
+
+	// Pointer to [length, capacity, pointer] u32 values - already shifted.
+	#rawPointer: number;
+	constructor(pointer: number) {
+		this.#rawPointer = pointer;
+	}
+
+	get length(): number {
+		return memory.views.u32[this.#rawPointer];
+	}
+	get capacity(): number {
+		return memory.views.u32[this.#rawPointer + 1];
+	}
+	get #pointer(): number {
+		return memory.views.u32[this.#rawPointer + 2];
+	}
+
+	get(index: number): number {
+		// TODO
+		return 0;
+	}
+	set(index: number, value: number): void {
+		// TODO
+	}
+
+	push(value: number): number {
+		// TODO
+		if (this.length === this.capacity) {
+			this.grow(this.length * 2);
+		}
+		return this.length;
+	}
+
+	grow(newLength: number): void {
+		// TODO
+	}
+}

--- a/src/storage/Vec.ts
+++ b/src/storage/Vec.ts
@@ -2,6 +2,8 @@ import { memory } from '../utils/memory';
 
 /**
  * A `Vec<u32>`.
+ *
+ * Create with `Vec.new()` or `Vec.fromPointer`.
  */
 export class Vec {
 	static size = 12;
@@ -14,39 +16,209 @@ export class Vec {
 		return new this(memory.alloc(this.size) >> 2);
 	}
 
-	// Pointer to [length, capacity, pointer] u32 values - already shifted.
+	/**
+	 * The raw pointer to this Vecs `[length, capacity, pointer]`.
+	 * All are u32 values - pointer already shifted for u32 access.
+	 */
 	#rawPointer: number;
 	constructor(pointer: number) {
 		this.#rawPointer = pointer;
 	}
 
+	/**
+	 * The length, in elements, of this Vec.
+	 * If set, will grow if needed and initialize new elements to 0.
+	 */
 	get length(): number {
 		return memory.views.u32[this.#rawPointer];
 	}
+	set length(newLength: number) {
+		if (newLength > this.capacity) {
+			this.grow(newLength);
+		} else if (newLength < this.length) {
+			memory.set(
+				(this.#rawPointer + newLength) << 2,
+				this.length - newLength,
+				0,
+			);
+		}
+		memory.views.u32[this.#rawPointer] = newLength;
+	}
+
+	/**
+	 * The capacity, in elements, of this Vec.
+	 * Can be set to resize.
+	 */
 	get capacity(): number {
 		return memory.views.u32[this.#rawPointer + 1];
 	}
-	get #pointer(): number {
-		return memory.views.u32[this.#rawPointer + 2];
-	}
-
-	get(index: number): number {
-		// TODO
-		return 0;
-	}
-	set(index: number, value: number): void {
-		// TODO
-	}
-
-	push(value: number): number {
-		// TODO
-		if (this.length === this.capacity) {
-			this.grow(this.length * 2);
+	set capacity(newCapacity: number) {
+		if (newCapacity > this.capacity) {
+			this.grow(newCapacity);
 		}
+		memory.views.u32[this.#rawPointer + 1] = newCapacity;
+	}
+
+	/**
+	 * The pointer to this Vecs elements.
+	 */
+	get #pointer(): number {
+		return memory.views.u32[this.#rawPointer + 2] >> 2;
+	}
+
+	/**
+	 * Returns the element at the provided index in the Vec.
+	 * Throws if `index` is out of bounds.
+	 * @param index The index of this Vec to get.
+	 * @returns The value at that index.
+	 */
+	get(index: number): number {
+		if (index > this.length) {
+			throw new RangeError(
+				'Out of bounds index access in Vec.prototype.get()!',
+			);
+		}
+		return memory.views.u32[this.#pointer + index];
+	}
+
+	/**
+	 * Sets the element at the provided index in the Vec.
+	 * Throws if `index` is out of bounds.
+	 * @param index The index of this Vec to set.
+	 * @param value The value to set the provided `index` to.
+	 */
+	set(index: number, value: number): void {
+		if (index > this.length) {
+			throw new RangeError(
+				'Out of bounds index access in Vec.prototype.get()!',
+			);
+		}
+		memory.views.u32[this.#pointer + index] = value;
+	}
+
+	/**
+	 * Pushes a new value into this Vec and returns the Vec's new length.
+	 * @param value
+	 * @returns
+	 */
+	push(value: number): number {
+		if (this.length === this.capacity) {
+			this.grow(this.length * 2 || 8);
+		}
+		memory.views.u32[this.#pointer + this.length] = value;
+		memory.views.u32[this.#rawPointer]++;
 		return this.length;
 	}
 
-	grow(newLength: number): void {
-		// TODO
+	/**
+	 * Removes the last element of this Vec and returns it.
+	 */
+	pop(): number {
+		memory.views.u32[this.#rawPointer]--;
+		const value = memory.views.u32[this.#pointer + this.length];
+		memory.views.u32[this.#pointer + this.length] = 0;
+		return value;
 	}
+
+	/**
+	 * Grows the Vec to the specified size.
+	 * @param newCapacity The new length - **in elements** - of this Vec.
+	 */
+	grow(newCapacity: number): void {
+		if (newCapacity <= this.capacity) {
+			return;
+		}
+		memory.reallocAt((this.#rawPointer + 2) << 2, newCapacity * 4);
+		memory.views.u32[this.#rawPointer + 1] = newCapacity;
+	}
+}
+
+/*---------*\
+|   TESTS   |
+\*---------*/
+if (import.meta.vitest) {
+	const { it, expect, beforeEach, vi } = import.meta.vitest;
+
+	beforeEach(() => {
+		memory.init(10_000);
+		return () => {
+			memory.UNSAFE_CLEAR_ALL();
+			vi.clearAllMocks();
+		};
+	});
+
+	it('creates a Vec with length/capacity 0', () => {
+		const vec = Vec.new();
+		expect(vec).toHaveProperty('length', 0);
+		expect(vec).toHaveProperty('capacity', 0);
+	});
+
+	it('pushes elements', () => {
+		const vec = Vec.new();
+		expect(vec.length).toBe(0);
+
+		for (let i = 1; i < 10; i++) {
+			const newLength = vec.push(5);
+			expect(newLength).toBe(i);
+			expect(vec.length).toBe(i);
+			expect(vec.capacity).toBeGreaterThanOrEqual(vec.length);
+		}
+	});
+
+	it('gets/sets elements', () => {
+		const vec = Vec.new();
+
+		for (let i = 0; i < 10; i++) {
+			vec.push(i);
+		}
+		expect(vec.length).toBe(10);
+
+		for (let i = 0; i < 10; i++) {
+			expect(vec.get(i)).toBe(i);
+		}
+		for (let i = 0; i < 10; i++) {
+			vec.set(i, (i + 1) * 2);
+		}
+		for (let i = 0; i < 10; i++) {
+			expect(vec.get(i)).toBe((i + 1) * 2);
+		}
+	});
+
+	it('pops elements', () => {
+		const vec = Vec.new();
+
+		for (let i = 0; i < 10; i++) {
+			vec.push(i);
+		}
+
+		expect(vec.length).toBe(10);
+
+		for (let i = 0; i < 10; i++) {
+			expect(vec.pop()).toBe(9 - i);
+			expect(vec.length).toBe(9 - i);
+		}
+	});
+
+	it('grow() grows to fit elements', () => {
+		const vec = Vec.new();
+
+		expect(vec.capacity).toBe(0);
+		vec.grow(10);
+		expect(vec.capacity).toBe(10);
+		vec.grow(100);
+		expect(vec.capacity).toBe(100);
+		vec.grow(1000);
+		expect(vec.capacity).toBe(1000);
+	});
+
+	it('setting length/capacity works', () => {
+		const vec = Vec.new();
+		expect(vec.length).toBe(0);
+		vec.length = 10;
+		expect(vec.length).toBe(10);
+		expect(vec.capacity).toBe(10);
+		vec.capacity = 30;
+		expect(vec.length).toBe(10);
+		expect(vec.capacity).toBe(30);
+	});
 }

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -178,18 +178,18 @@ export class World {
 		this.entities.setRow(entityId, targetTable.length - 1);
 	}
 
-	#getTable(tableId: bigint): Table {
-		let table = this.#archetypeToTable.get(tableId);
+	#getTable(archetype: bigint): Table {
+		let table = this.#archetypeToTable.get(archetype);
 		if (table) {
 			return table;
 		}
 		table = new Table(
-			Array.from(bits(tableId), cid => this.components[cid]),
-			tableId,
+			Array.from(bits(archetype), cid => this.components[cid]),
+			archetype,
 			this.tables.length,
 		);
 		this.tables.push(table);
-		this.#archetypeToTable.set(tableId, table);
+		this.#archetypeToTable.set(archetype, table);
 
 		for (const query of this.queries) {
 			query.testAdd(table);

--- a/src/world/config.ts
+++ b/src/world/config.ts
@@ -22,7 +22,7 @@ const getCompleteConfig = (
 	memorySize: 64 * MB,
 	useSharedMemory: false,
 	isMainThread: typeof document !== 'undefined',
-	getNewTableSize: (prev: number) => (prev === 0 ? 8 : prev * 2),
+	getNewTableSize: (prev: number) => prev * 2 || 8,
 	...config,
 });
 


### PR DESCRIPTION
This rewrites `Entities` and parts of `Table` and `World` to be a little cleaner conceptually and more readable. Most excitingly, this removes the two "nullish" tables and moves to one.

Fixes https://github.com/JaimeGensler/thyseus/issues/11 (cc @kayhhh)
Also cc @3mcd because this potentially has some minor (easy to resolve) conflicts with Commands rewriting

Reviews/questions/comments are welcome but not expected! 

**Changes:**
- Added `Vec` class, which abstracts over some common functionality
    - For internal use only right now
    - Only handles u32s right now, I’d like to work out an externally useable abstraction in the future.
- Complete rewrite of `Entities` internals
    - Less code, more comments. Yay!
    - Now owns entity generations
        - We end up with some slight data duplication that we didn’t before (generations are held both by `Entity` component and entities), but this is a fine trade-off for stability, readability, and modularity
    - Now owns list of freed entities
    - Lazy allocation
        - Don’t pre-allocate a set amount of entities, just grow as needed
     - Removed `Entities.fromWorld` - just using the constructor
- Table
    - Removed `Table.new` - just using the constructor
    - `grow()` accepts a new capacity
        - Code is a little more modular for this, but it also means consumers of the library can find individual tables and resize them independent of the world config
    - Removed `#world` as it was no longer needed
    - Lazy allocation
        - Don’t allocate for columns when constructing - less code & localizes column allocation to `grow()`
    - Renamed `table.bitfield` to `table.archetype` for clarity.
    - `move()` can return null
- World
    - Renamed `world.archetypes` to `world.tables` for clarity.
- The “empty” and “recycled” tables have been merged into one “true” empty table
    - This table is essentially a placeholder so that archetype/table 0 means an entity isn’t alive
    - Has no columns (like the previous "empty" table, but unlike the previous "recycled" table)
    - Archetype is 0n (like both previously)
