### PR TITLE
[world] [table] Fix despawn bug

### DIFF
--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -17,7 +17,7 @@ export class World {
 	/**
 	 * Constructs and returns a new `WorldBuilder`.
 	 * @param config The config of the world.
-	 * @returns A `WorldBuilder`
+	 * @returns A `WorldBuilder`.
 	 */
 	static new(config?: Partial<SingleThreadedWorldConfig>): WorldBuilder;
 	/**
@@ -158,21 +158,20 @@ export class World {
 
 		const currentTable = this.tables[this.entities.getTableId(entityId)];
 		const targetTable = this.#getTable(targetArchetype);
-
 		if (targetTable.length === targetTable.capacity) {
 			targetTable.grow(this.config.getNewTableSize(targetTable.capacity));
 		}
 
 		const row = this.entities.getRow(entityId);
-
-		// If the moving entity is the last element, move() returns the id of
-		// the entity that's moving tables. This means we set row for that
-		// entity twice, but the last set will be correct.
-		const backfilledEntity = currentTable.move(row, targetTable);
-		if (backfilledEntity !== null) {
+		if (currentTable.archetype === 0n) {
+			targetTable.add(entityId);
+		} else {
+			// If the moving entity is the last element, move() returns the id
+			// of the entity that's moving tables. This means we set row for
+			// that entity twice, but the last set will be correct.
+			const backfilledEntity = currentTable.move(row, targetTable);
 			this.entities.setRow(backfilledEntity, row);
 		}
-
 		if (targetArchetype === 0n) {
 			this.entities.freeId(entityId);
 		}

--- a/src/world/index.ts
+++ b/src/world/index.ts
@@ -1,6 +1,6 @@
 export { World } from './World';
 export { WorldDescriptor } from './WorldDescriptor';
 
-export type { Plugin } from './defaultPlugin';
+export type { Plugin } from './Plugin';
 export type { WorldBuilder } from './WorldBuilder';
 export type { WorldConfig } from './config';


### PR DESCRIPTION
Fixes https://github.com/JaimeGensler/thyseus/issues/17

This was a combination of two issues: 
1) We move entities to their final table before inserting new data - including `Entity`. At the same time, we assume `Entity` data exists when we perform _any_ move in order to track entity backfills. Resolved by adding an `add` method on tables for use when entities are coming from the empty table.
2) Off by one error 🤦‍♂️ 