### PR TITLE
[struct] Rework substruct for better performance

### DIFF
--- a/src/storage/Entity.ts
+++ b/src/storage/Entity.ts
@@ -46,6 +46,9 @@ export class Entity extends BaseEntity {
 
 	/**
 	 * Verifies if this entity has a specific component type.
+	 *
+	 * **NOTE: Only works for queries running on the main thread!**
+	 *
 	 * @param componentType The type (class) of the component to detect.
 	 * @returns `boolean`, true if the entity has the component and false if it does not.
 	 */

--- a/src/storage/initStruct.ts
+++ b/src/storage/initStruct.ts
@@ -8,6 +8,8 @@ export function initStruct(instance: object): void {
 		Memory.isInitialized, // Structs require memory to be initialized.
 		'Tried to create a struct before memory was initialized.',
 	);
+	const constructor: any = instance.constructor;
+	constructor.initializer?.(instance);
 
 	if ((instance as any).__$$b) {
 		return; // We already initialized this struct, likely in the super() call.
@@ -16,7 +18,7 @@ export function initStruct(instance: object): void {
 	(instance as any).__$$b =
 		byteOffset !== 0
 			? byteOffset // Managed Struct
-			: Memory.alloc((instance.constructor as Struct).size!); // Unmanaged Struct
+			: Memory.alloc((constructor as Struct).size!); // Unmanaged Struct
 }
 export function dropStruct(instance: object): void {
 	const structType = instance.constructor as Struct;

--- a/src/struct/array.ts
+++ b/src/struct/array.ts
@@ -11,11 +11,11 @@ export function array({ type, length }: ArrayOptions) {
 		propertyKey: string | symbol,
 	) {
 		const typeConstructor = TYPE_TO_CONSTRUCTOR[type];
-		const offset = addField(
-			propertyKey,
-			typeConstructor.BYTES_PER_ELEMENT,
-			typeConstructor.BYTES_PER_ELEMENT * length,
-		);
+		const offset = addField({
+			name: propertyKey,
+			size: typeConstructor.BYTES_PER_ELEMENT * length,
+			alignment: typeConstructor.BYTES_PER_ELEMENT,
+		});
 		const shift = 31 - Math.clz32(typeConstructor.BYTES_PER_ELEMENT);
 		Object.defineProperty(prototype, propertyKey, {
 			enumerable: true,

--- a/src/struct/primitives.ts
+++ b/src/struct/primitives.ts
@@ -7,11 +7,11 @@ function createPrimativeFieldDecorator(typeName: PrimitiveName) {
 		propertyKey: string | symbol,
 	) {
 		const type = TYPE_TO_CONSTRUCTOR[typeName];
-		const offset = addField(
-			propertyKey,
-			type.BYTES_PER_ELEMENT,
-			type.BYTES_PER_ELEMENT,
-		);
+		const offset = addField({
+			name: propertyKey,
+			size: type.BYTES_PER_ELEMENT,
+			alignment: type.BYTES_PER_ELEMENT,
+		});
 		const shift = 31 - Math.clz32(type.BYTES_PER_ELEMENT);
 
 		Object.defineProperty(prototype, propertyKey, {
@@ -44,11 +44,11 @@ export const bool = function fieldDecorator(
 	prototype: object,
 	propertyKey: string | symbol,
 ) {
-	const offset = addField(
-		propertyKey,
-		Uint8Array.BYTES_PER_ELEMENT,
-		Uint8Array.BYTES_PER_ELEMENT,
-	);
+	const offset = addField({
+		name: propertyKey,
+		size: Uint8Array.BYTES_PER_ELEMENT,
+		alignment: Uint8Array.BYTES_PER_ELEMENT,
+	});
 
 	Object.defineProperty(prototype, propertyKey, {
 		enumerable: true,

--- a/src/struct/string.ts
+++ b/src/struct/string.ts
@@ -21,12 +21,12 @@ function getByteLength(val: string) {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 export function string(prototype: object, propertyKey: string | symbol) {
-	const offset = addField(
-		propertyKey,
-		Uint32Array.BYTES_PER_ELEMENT,
-		Uint32Array.BYTES_PER_ELEMENT * 3,
-		[8],
-	);
+	const offset = addField({
+		name: propertyKey,
+		size: Uint32Array.BYTES_PER_ELEMENT * 3,
+		alignment: Uint32Array.BYTES_PER_ELEMENT,
+		pointers: [8],
+	});
 
 	Object.defineProperty(prototype, propertyKey, {
 		enumerable: true,

--- a/src/struct/struct.ts
+++ b/src/struct/struct.ts
@@ -63,11 +63,12 @@ type StructDecorator = {
 	): (prototype: object, propertyKey: string | symbol) => void;
 };
 export const struct: StructDecorator = function struct(targetClass) {
-	const { size, alignment, pointers } = resetFields();
+	const { size, alignment, pointers, init } = resetFields();
 	return class extends targetClass {
 		static size = size;
 		static alignment = alignment;
 		static pointers = pointers;
+		static initializer = init;
 
 		declare __$$b: number;
 


### PR DESCRIPTION
A recent fix to substructs degraded performance for them pretty dramatically. This new implementation initializes substruct instances in the `initStruct` call, which means we don't need to `alloc()` or even have the browser create objects during `get`s.

Also migrates to an object for the `addField` parameter for better readability