### PR TITLE
[commands] Rewrite commands to use structs, fix commands bugs

### DIFF
--- a/.changeset/heavy-news-eat.md
+++ b/.changeset/heavy-news-eat.md
@@ -1,0 +1,5 @@
+---
+'thyseus': patch
+---
+
+Does not add known no-op commands to the command queue

--- a/.changeset/quiet-pumpkins-retire.md
+++ b/.changeset/quiet-pumpkins-retire.md
@@ -1,0 +1,5 @@
+---
+'thyseus': minor
+---
+
+Rewrite Commands to use structs, add push() method

--- a/.changeset/tiny-trains-thank.md
+++ b/.changeset/tiny-trains-thank.md
@@ -1,0 +1,5 @@
+---
+'thyseus': minor
+---
+
+Add World.prototype.getComponentId

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -95,6 +95,9 @@ export class Commands {
 	 * @returns `this`, for chaining.
 	 */
 	despawn(id: bigint): void {
+		if (this.#entities.wasDespawned(id)) {
+			return;
+		}
 		const command = this.push(
 			RemoveComponentCommand,
 			RemoveComponentCommand.size,
@@ -116,6 +119,9 @@ export class Commands {
 		entityId: bigint,
 		component: NotFunction<T>,
 	): void {
+		if (this.#entities.wasDespawned(entityId)) {
+			return;
+		}
 		const componentType: Struct = component.constructor as any;
 
 		DEV_ASSERT(
@@ -145,6 +151,9 @@ export class Commands {
 			componentType !== Entity,
 			'Tried to add Entity component, which is forbidden.',
 		);
+		if (this.#entities.wasDespawned(entityId)) {
+			return;
+		}
 
 		const command = this.push(
 			AddComponentCommand,
@@ -168,6 +177,9 @@ export class Commands {
 			componentType !== Entity,
 			'Tried to remove Entity component, which is forbidden.',
 		);
+		if (this.#entities.wasDespawned(entityId)) {
+			return;
+		}
 		const command = this.push(
 			RemoveComponentCommand,
 			RemoveComponentCommand.size,

--- a/src/commands/commandTypes/ClearEventQueueCommand.ts
+++ b/src/commands/commandTypes/ClearEventQueueCommand.ts
@@ -1,0 +1,18 @@
+import { Memory } from '../../utils';
+
+const { views } = Memory;
+export class ClearEventQueueCommand {
+	static size = 4;
+	static alignment = 4;
+
+	declare __$$b: number;
+	constructor() {
+		this.__$$b = 0;
+	}
+	get queueLengthPointer(): number {
+		return views.u32[this.__$$b >> 2];
+	}
+	set queueLengthPointer(value: number) {
+		views.u32[this.__$$b >> 2] = value;
+	}
+}

--- a/src/commands/commandTypes/ComponentCommands.ts
+++ b/src/commands/commandTypes/ComponentCommands.ts
@@ -1,0 +1,32 @@
+import { Memory } from '../../utils';
+
+const { views } = Memory;
+class BaseComponentCommand {
+	static size = 16; // Size is for struct internals, payload follows
+	static alignment = 8;
+	declare __$$b: number;
+
+	constructor() {
+		this.__$$b = 0;
+	}
+
+	get entityId() {
+		return views.u64[this.__$$b >> 3];
+	}
+	set entityId(value: bigint) {
+		views.u64[this.__$$b >> 3] = value;
+	}
+	get componentId() {
+		return views.u16[(this.__$$b + 8) >> 1];
+	}
+	set componentId(value: number) {
+		views.u16[(this.__$$b + 8) >> 1] = value;
+	}
+}
+
+export class AddComponentCommand extends BaseComponentCommand {
+	get dataStart() {
+		return this.__$$b + AddComponentCommand.size;
+	}
+}
+export class RemoveComponentCommand extends BaseComponentCommand {}

--- a/src/commands/commandTypes/index.ts
+++ b/src/commands/commandTypes/index.ts
@@ -1,0 +1,5 @@
+export {
+	AddComponentCommand,
+	RemoveComponentCommand,
+} from './ComponentCommands';
+export { ClearEventQueueCommand } from './ClearEventQueueCommand';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,10 @@
 export { Commands } from './Commands';
 export { CommandsDescriptor } from './CommandsDescriptor';
 export { applyCommands } from './applyCommands';
+export {
+	AddComponentCommand,
+	RemoveComponentCommand,
+	ClearEventQueueCommand,
+} from './commandTypes';
 
 export type { EntityCommands } from './EntityCommands';

--- a/src/storage/Entities.ts
+++ b/src/storage/Entities.ts
@@ -96,6 +96,19 @@ export class Entities {
 	}
 
 	/**
+	 * Checks if the provided entity id was despawned.
+	 * @param entityId The id of the entity to check.
+	 * @returns A `boolean`, true if the entity is alive and false if it is not.
+	 */
+	wasDespawned(entityId: bigint): boolean {
+		const index = getIndex(entityId);
+		return (
+			this.#generations.length > index &&
+			this.#generations.get(index) !== getGeneration(entityId)
+		);
+	}
+
+	/**
 	 * Verifies if an entity has a specific component type.
 	 * @param entityId The id of the entity
 	 * @param componentType The type (class) of the component to detect.

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -73,7 +73,7 @@ export class World {
 		this.#archetypeToTable.set(0n, emptyTable);
 
 		this.entities = new Entities(this);
-		this.commands = Commands.fromWorld(this);
+		this.commands = new Commands(this);
 
 		for (const eventType of eventTypes) {
 			const pointer = this.threads.queue(() => {

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -180,6 +180,20 @@ export class World {
 		this.entities.setRow(entityId, targetTable.length - 1);
 	}
 
+	/**
+	 * Gets the internal id for a component in this world.
+	 * May differ from world to world.
+	 * @param componentType The component type to get an id for.
+	 * @returns The numeric id of the component.
+	 */
+	getComponentId(componentType: Struct): number {
+		DEV_ASSERT(
+			this.components.includes(componentType),
+			`Tried to get id of unregistered component "${componentType.name}"`,
+		);
+		return this.components.indexOf(componentType);
+	}
+
 	#getTable(archetype: bigint): Table {
 		let table = this.#archetypeToTable.get(archetype);
 		if (table) {

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -157,6 +157,10 @@ export class World {
 		}
 
 		const currentTable = this.tables[this.entities.getTableId(entityId)];
+		if (currentTable.archetype === targetArchetype) {
+			// No need to move, we're already there!
+			return;
+		}
 		const targetTable = this.#getTable(targetArchetype);
 		if (targetTable.length === targetTable.capacity) {
 			targetTable.grow(this.config.getNewTableSize(targetTable.capacity));


### PR DESCRIPTION
Rewrites commands to internally use structs, which prevents silly bugs like writing a value as a u32 and reading it as a u16 (certainly not that I've ever done that 🤫 ). Also a solid step toward making Commands an API that consumers can hook into - more work to be done on this front in the future.

Resolves https://github.com/JaimeGensler/thyseus/issues/6, https://github.com/JaimeGensler/thyseus/issues/18, & mitigates https://github.com/JaimeGensler/thyseus/issues/22, but more work to be done