### PR TITLE
[structs] [commands] Improve struct copy/drop logic

### DIFF
--- a/.changeset/fair-tools-rule.md
+++ b/.changeset/fair-tools-rule.md
@@ -1,0 +1,5 @@
+---
+'thyseus': minor
+---
+
+Define copy/drop functions for structs rather than pointer array

--- a/.changeset/lucky-carpets-begin.md
+++ b/.changeset/lucky-carpets-begin.md
@@ -1,0 +1,5 @@
+---
+'thyseus': patch
+---
+
+Sort components by alignment (largest -> smallest)

--- a/src/queries/Query.ts
+++ b/src/queries/Query.ts
@@ -181,6 +181,7 @@ if (import.meta.vitest) {
 
 	it('testAdd adds tables only if a filter passes', async () => {
 		class ZST {
+			static copy() {}
 			static size = 0;
 		}
 		const world = await createWorld(ZST);
@@ -239,6 +240,7 @@ if (import.meta.vitest) {
 
 		class Vec3 {
 			static size = 24;
+			static copy() {}
 			constructor() {
 				initStruct(this);
 			}
@@ -247,6 +249,7 @@ if (import.meta.vitest) {
 
 		it('yields normal elements for all table members', async () => {
 			class ZST {
+				static copy() {}
 				static size = 0;
 			}
 			const world = await createWorld(Vec3, ZST);

--- a/src/storage/Entity.ts
+++ b/src/storage/Entity.ts
@@ -5,6 +5,9 @@ import type { Struct } from '../struct';
 import type { Entities } from './Entities';
 
 export class Entity extends BaseEntity {
+	static copy(from: number, to: number) {
+		Memory.copy(from, this.size, to);
+	}
 	static size = 8;
 	static alignment = 8;
 

--- a/src/storage/Table.ts
+++ b/src/storage/Table.ts
@@ -58,10 +58,9 @@ export class Table {
 	}
 
 	move(row: number, targetTable: Table): bigint {
-		const { u32, u64 } = Memory.views;
 		// We never call move for the empty table, so ptr will be defined.
 		const ptr = this.#getColumn(Entity);
-		const lastEntity = u64[(ptr >> 3) + this.length - 1];
+		const lastEntity = Memory.views.u64[(ptr >> 3) + this.length - 1];
 		for (const component of this.#components) {
 			const componentPointer =
 				this.#getColumn(component) + row * component.size!;
@@ -73,9 +72,7 @@ export class Table {
 						targetTable.length * component.size!,
 				);
 			} else {
-				for (const pointerOffset of component.pointers ?? []) {
-					Memory.free(u32[(componentPointer + pointerOffset) >> 2]);
-				}
+				component.drop?.(componentPointer);
 			}
 		}
 		targetTable.length++;

--- a/src/storage/initStruct.ts
+++ b/src/storage/initStruct.ts
@@ -9,7 +9,7 @@ export function initStruct(instance: object): void {
 		'Tried to create a struct before memory was initialized.',
 	);
 	const constructor: any = instance.constructor;
-	constructor.initializer?.(instance);
+	constructor.initialize?.(instance);
 
 	if ((instance as any).__$$b) {
 		return; // We already initialized this struct, likely in the super() call.
@@ -21,12 +21,8 @@ export function initStruct(instance: object): void {
 			: Memory.alloc((constructor as Struct).size!); // Unmanaged Struct
 }
 export function dropStruct(instance: object): void {
-	const structType = instance.constructor as Struct;
-	const byteOffset = (instance as any).__$$b;
-	for (const pointer of structType.pointers ?? []) {
-		Memory.free(Memory.views.u32[(byteOffset + pointer) >> 2]);
-	}
-	Memory.free(byteOffset);
+	(instance.constructor as Struct).drop?.((instance as any).__$$b);
+	Memory.free((instance as any).__$$b);
 }
 
 export function createManagedStruct<T extends Struct>(

--- a/src/struct/addField.ts
+++ b/src/struct/addField.ts
@@ -1,3 +1,5 @@
+import { Memory } from '../utils';
+
 export const TYPE_TO_CONSTRUCTOR = {
 	u8: Uint8Array,
 	u16: Uint16Array,
@@ -11,7 +13,10 @@ export const TYPE_TO_CONSTRUCTOR = {
 	f64: Float64Array,
 } as const;
 export type PrimitiveName = keyof typeof TYPE_TO_CONSTRUCTOR;
-type Initializer = (value: Record<string | symbol, any>) => void;
+type Instance = { __$$b: number } & Record<string | symbol, any>;
+export type Initialize = (instance: Instance) => void;
+export type Copy = (from: number, to: number) => void;
+export type Drop = (offset: number) => void;
 
 let currentAlignment = 1;
 let currentSize = 0;
@@ -19,8 +24,9 @@ let currentSize = 0;
 const keys: (string | symbol)[] = [];
 const alignments: number[] = [];
 let currentOffset: Record<string | symbol, number> = {};
-let currentPointers: Record<string | symbol, number[]> = {};
-const currentInitializers: Initializer[] = [];
+const currentInitializes: Initialize[] = [];
+const currentCopies: Copy[] = [];
+const currentDrops: Drop[] = [];
 
 const updateOffsets = (
 	newKey: string | symbol,
@@ -54,23 +60,28 @@ type FieldProperties = {
 	name: string | symbol;
 	size: number;
 	alignment: number;
-	pointers?: number[];
-	initializer?(instance: Record<string | symbol, any>): void;
+	initialize?: Initialize;
+	copy?: Copy;
+	drop?: Drop;
 };
 export function addField({
 	name,
 	size,
 	alignment,
-	pointers,
-	initializer,
+	initialize,
+	copy,
+	drop,
 }: FieldProperties): Record<string | symbol, number> {
-	if (initializer) {
-		currentInitializers.push(initializer);
+	if (initialize) {
+		currentInitializes.push(initialize);
+	}
+	if (copy) {
+		currentCopies.push(copy);
+	}
+	if (drop) {
+		currentDrops.push(drop);
 	}
 	currentAlignment = Math.max(currentAlignment, alignment);
-	if (pointers) {
-		currentPointers[name] = pointers;
-	}
 
 	updateOffsets(name, alignment, size);
 	currentSize += size;
@@ -79,21 +90,27 @@ export function addField({
 }
 
 export function resetFields() {
-	const pointers: number[] = [];
-	for (const key in currentPointers) {
-		for (const pointer of currentPointers[key]) {
-			pointers.push(pointer + currentOffset[key]);
-		}
-	}
-
-	const initializers = [...currentInitializers];
+	const initializers = [...currentInitializes];
+	const drops = [...currentDrops];
+	const copies = [...currentCopies];
+	const size = Math.ceil(currentSize / currentAlignment) * currentAlignment;
 	const result = {
-		size: Math.ceil(currentSize / currentAlignment) * currentAlignment,
+		size,
 		alignment: currentAlignment,
-		pointers,
-		init(value: Record<string | symbol, any>) {
-			for (const initializer of [...initializers]) {
-				initializer(value);
+		initialize(instance: Instance) {
+			for (const initialize of initializers) {
+				initialize(instance);
+			}
+		},
+		drop(pointer: number) {
+			for (const drop of drops) {
+				drop(pointer);
+			}
+		},
+		copy(from: number, to: number) {
+			Memory.copy(from, size, to);
+			for (const copy of copies) {
+				copy(from, to);
 			}
 		},
 	};
@@ -101,9 +118,10 @@ export function resetFields() {
 	currentAlignment = 1;
 
 	currentOffset = {};
-	currentPointers = {};
 	keys.length = 0;
 	alignments.length = 0;
-	currentInitializers.length = 0;
+	currentInitializes.length = 0;
+	currentCopies.length = 0;
+	currentDrops.length = 0;
 	return result;
 }

--- a/src/struct/struct.ts
+++ b/src/struct/struct.ts
@@ -1,4 +1,4 @@
-import { resetFields } from './addField';
+import { resetFields, type Copy, type Drop, Initialize } from './addField';
 import {
 	u8,
 	u16,
@@ -33,7 +33,20 @@ export type Struct = {
 	 */
 	size?: number;
 
-	pointers?: number[];
+	/**
+	 * A function that handles initializing some fields of an instance of a struct.
+	 */
+	initialize?: Initialize;
+
+	/**
+	 * A function that creates a **deep** copy given an instance of a struct.
+	 */
+	copy?: Copy;
+
+	/**
+	 * A function that fully drops an instance of a struct.
+	 */
+	drop?: Drop;
 
 	new (): object;
 };
@@ -63,12 +76,13 @@ type StructDecorator = {
 	): (prototype: object, propertyKey: string | symbol) => void;
 };
 export const struct: StructDecorator = function struct(targetClass) {
-	const { size, alignment, pointers, init } = resetFields();
+	const { size, alignment, initialize, copy, drop } = resetFields();
 	return class extends targetClass {
 		static size = size;
 		static alignment = alignment;
-		static pointers = pointers;
-		static initializer = init;
+		static initialize = initialize;
+		static copy = copy;
+		static drop = drop;
 
 		declare __$$b: number;
 

--- a/src/struct/substruct.ts
+++ b/src/struct/substruct.ts
@@ -13,10 +13,18 @@ export function substruct(struct: Struct) {
 			name: propertyKey,
 			size: struct.size!,
 			alignment: struct.alignment!,
-			pointers: struct.pointers,
-			initializer(val) {
+			initialize(val) {
 				val[hiddenKey] = new struct();
 				dropStruct(val[hiddenKey]);
+			},
+			copy(from, to) {
+				struct.copy!(
+					from + offset[propertyKey],
+					to + offset[propertyKey],
+				);
+			},
+			drop(pointer) {
+				struct.drop?.(pointer + offset[propertyKey]);
 			},
 		});
 

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -57,7 +57,11 @@ export class World {
 	) {
 		this.config = config;
 		this.threads = threads;
-		this.components = components;
+		// Components are sorted by alignment (largest -> smallest) so we can
+		// create "default" data for all of them without needing to pad any.
+		this.components = components.sort(
+			(a, z) => z.alignment! - a.alignment!,
+		);
 
 		Memory.init(
 			this.threads.queue(() =>


### PR DESCRIPTION
Also fixes a nasty issue where initial data wasn't aligned correctly so copies wouldn't work right

Resolves https://github.com/JaimeGensler/thyseus/issues/28
Also I think resolves the final issues related to https://github.com/JaimeGensler/thyseus/issues/22 - current bug with strings seems related to strings themselves