### PR TITLE
[vec] [entities] [strings] Fix crashes related to strings, allow multithreaded string usage

### DIFF
--- a/src/storage/Vec.ts
+++ b/src/storage/Vec.ts
@@ -37,7 +37,7 @@ export class Vec {
 			this.grow(newLength);
 		} else if (newLength < this.length) {
 			Memory.set(
-				(this.#rawPointer + newLength) << 2,
+				(this.#pointer + newLength) << 2,
 				this.length - newLength,
 				0,
 			);

--- a/src/struct/string.ts
+++ b/src/struct/string.ts
@@ -29,19 +29,13 @@ export function string(prototype: object, propertyKey: string | symbol) {
 		alignment: Uint32Array.BYTES_PER_ELEMENT,
 		copy(from, to) {
 			const fromStart = from + offset[propertyKey];
-			const length = Memory.u32[fromStart >> 2];
-			const newPointer = length > 0 ? Memory.alloc(length) : 0;
-			if (newPointer !== 0) {
-				Memory.copy(
-					Memory.u32[(fromStart + 8) >> 2],
-					length,
-					newPointer,
-				);
-			}
 			const toStart = to + offset[propertyKey];
-			Memory.u32[toStart >> 2] = length;
-			Memory.u32[(toStart + 4) >> 2] = length;
-			Memory.u32[(toStart + 8) >> 2] = newPointer;
+
+			Memory.u32[toStart >> 2] = Memory.u32[fromStart >> 2];
+			Memory.u32[(toStart + 4) >> 2] = Memory.u32[(fromStart + 4) >> 2];
+			Memory.u32[(toStart + 8) >> 2] = Memory.copyPointer(
+				Memory.u32[(fromStart + 8) >> 2],
+			);
 		},
 		drop(pointer) {
 			Memory.free(Memory.u32[(pointer + offset[propertyKey] + 8) >> 2]);

--- a/src/struct/string.ts
+++ b/src/struct/string.ts
@@ -16,6 +16,7 @@ export function serializeString(pointer: number, value: string): void {
 	if (byteLength > capacity) {
 		Memory.reallocAt(pointer + 8, byteLength);
 	}
+	Memory.u32[pointer >> 2] = value.length;
 	const offset = Memory.u32[(pointer + 8) >> 2] >> 1;
 	for (let i = 0; i < value.length; i++) {
 		Memory.u16[offset + i] = value.charCodeAt(i);
@@ -27,20 +28,20 @@ export function string(prototype: object, propertyKey: string | symbol) {
 		size: Uint32Array.BYTES_PER_ELEMENT * 3,
 		alignment: Uint32Array.BYTES_PER_ELEMENT,
 		copy(from, to) {
-			const instanceStart = from + offset[propertyKey];
-			const length = Memory.u32[instanceStart >> 2];
+			const fromStart = from + offset[propertyKey];
+			const length = Memory.u32[fromStart >> 2];
 			const newPointer = length > 0 ? Memory.alloc(length) : 0;
 			if (newPointer !== 0) {
 				Memory.copy(
-					Memory.u32[(instanceStart + 8) >> 2],
+					Memory.u32[(fromStart + 8) >> 2],
 					length,
 					newPointer,
 				);
 			}
-			const copyStart = to + offset[propertyKey];
-			Memory.u32[copyStart >> 2] = length;
-			Memory.u32[(copyStart + 4) >> 2] = length;
-			Memory.u32[(copyStart + 8) >> 2] = newPointer;
+			const toStart = to + offset[propertyKey];
+			Memory.u32[toStart >> 2] = length;
+			Memory.u32[(toStart + 4) >> 2] = length;
+			Memory.u32[(toStart + 8) >> 2] = newPointer;
 		},
 		drop(pointer) {
 			Memory.free(Memory.u32[(pointer + offset[propertyKey] + 8) >> 2]);
@@ -50,11 +51,35 @@ export function string(prototype: object, propertyKey: string | symbol) {
 	Object.defineProperty(prototype, propertyKey, {
 		enumerable: true,
 		get() {
-			deserializeString(this.__$$b + offset[propertyKey]);
+			return deserializeString(this.__$$b + offset[propertyKey]);
 		},
 		set(value: string) {
 			console.log(value);
 			serializeString(this.__$$b + offset[propertyKey], value);
 		},
+	});
+}
+
+/*---------*\
+|   TESTS   |
+\*---------*/
+if (import.meta.vitest) {
+	const { it, expect, beforeEach } = import.meta.vitest;
+
+	beforeEach(() => {
+		Memory.init(4_000);
+		return () => Memory.UNSAFE_CLEAR_ALL();
+	});
+
+	it('serializes simple strings', () => {
+		const ptr = Memory.alloc(12);
+		serializeString(ptr, 'test');
+		expect(deserializeString(ptr)).toBe('test');
+	});
+
+	it('serializes other strings', () => {
+		const ptr = Memory.alloc(12);
+		serializeString(ptr, '/Skybox.jpg');
+		expect(deserializeString(ptr)).toBe('/Skybox.jpg');
 	});
 }


### PR DESCRIPTION
Fairly confident this issue was more or less entirely caused by Vec using `#rawPointer` instead of `#pointer` - but did a little cleanup along the way. 

Incidentally also resolves https://github.com/JaimeGensler/thyseus/issues/26