### PR TITLE
[resources] Remove initialize() API, add fromWorld API

### DIFF
--- a/packages/thyseus/src/events/Events.ts
+++ b/packages/thyseus/src/events/Events.ts
@@ -261,12 +261,12 @@ if (import.meta.vitest) {
 		expect(reader.clear());
 		expect(pushCommandSpy).toHaveBeenCalledOnce();
 		const command = new ClearEventQueueCommand();
-		command.__$$b = 192;
+		command.__$$b = 184;
 		command.eventId = 0;
 		expect(pushCommandSpy).toHaveBeenCalledWith(command);
 
 		expect(writer.clear());
-		command.__$$b = 208;
+		command.__$$b = 200;
 		expect(pushCommandSpy).toHaveBeenCalledTimes(2);
 		expect(pushCommandSpy).toHaveBeenLastCalledWith(command);
 	});

--- a/packages/thyseus/src/world/World.ts
+++ b/packages/thyseus/src/world/World.ts
@@ -9,12 +9,12 @@ import {
 	ResourceRegistryKey,
 } from './registryKeys';
 import { StartSchedule, type ExecutorInstance } from '../schedule';
-import { isStruct, type Class, type Struct } from '../struct';
 import {
 	validateAndCompleteConfig,
 	type WorldConfig,
 	type SingleThreadedWorldConfig,
 } from './config';
+import type { Class, Struct } from '../struct';
 import type { ThreadGroup } from '../threads';
 import type { Query } from '../queries';
 
@@ -95,21 +95,10 @@ export class World {
 			);
 			eventsPointer += EventReader.size;
 		}
+	}
 
-		const resourceTypes = registry.get(ResourceRegistryKey)! as Set<Class>;
-		for (const resourceType of resourceTypes) {
-			if (isStruct(resourceType)) {
-				const res = new resourceType();
-				(res as any).__$$b = this.threads.queue(() =>
-					resourceType.size! !== 0
-						? Memory.alloc(resourceType.size!)
-						: 0,
-				);
-				this.resources.push(res);
-			} else if (threads.isMainThread) {
-				this.resources.push(new resourceType());
-			}
-		}
+	get isMainThread(): boolean {
+		return this.threads.isMainThread;
 	}
 
 	/**

--- a/packages/thyseus/src/world/WorldBuilder.ts
+++ b/packages/thyseus/src/world/WorldBuilder.ts
@@ -311,10 +311,10 @@ if (import.meta.vitest) {
 		},
 	});
 
-	const initializeTimeSpy = vi.fn();
+	const fromWorldSpy = vi.fn();
 	class Time {
 		static size = 8;
-		initialize = initializeTimeSpy;
+		static fromWorld = fromWorldSpy;
 	}
 
 	it('calls onAddSystem for all parameters', () => {
@@ -336,13 +336,13 @@ if (import.meta.vitest) {
 		builder.addSystems(mockSystem1, mockSystem2);
 	});
 
-	it('initializes resources', async () => {
+	it('uses fromWorld to construct resources if it exists', async () => {
 		const builder = World.new({ isMainThread: true }).registerResource(
 			Time,
 		);
-		expect(initializeTimeSpy).not.toHaveBeenCalled();
+		expect(fromWorldSpy).not.toHaveBeenCalled();
 		const world = await builder.build();
-		expect(initializeTimeSpy).toHaveBeenCalledWith(world);
+		expect(fromWorldSpy).toHaveBeenCalledWith(world);
 	});
 
 	it('passes SystemConfig to Executors', async () => {

--- a/packages/thyseus/src/world/WorldBuilder.ts
+++ b/packages/thyseus/src/world/WorldBuilder.ts
@@ -10,9 +10,9 @@ import {
 	type SystemConfig,
 	type SystemList,
 } from '../schedule';
+import { isStruct, type Class, type Struct } from '../struct';
 import type { Plugin } from './Plugin';
 import type { System } from '../systems';
-import { isStruct, type Class, type Struct } from '../struct';
 import type { WorldConfig } from './config';
 import {
 	ComponentRegistryKey,


### PR DESCRIPTION
Resources can currently have an instance `async initialize()` method that gets called only on the main thread - this changes this API to be done with a `fromWorld()` method. Using a static `async fromWorld()` method is more flexible as it allows custom setup on any thread, does not require instance methods, and is still as flexible as the previous API

Also added a `world.isMainThread` getter for easier checking