### PR TITLE
Accept a list of minimatch patterns for include/exclude

### DIFF
--- a/packages/rollup-plugin-thyseus/src/index.ts
+++ b/packages/rollup-plugin-thyseus/src/index.ts
@@ -7,8 +7,8 @@ import ts from 'typescript';
 import type { Plugin } from 'vite';
 
 type ThyseusPluginConfig = {
-	include?: string;
-	exclude?: string;
+	include?: string | string[];
+	exclude?: string | string[];
 } & TransformerConfig;
 
 export function thyseus({


### PR DESCRIPTION
The `createFilter` function from `@rollup/pluginutils` uses minimatch under the hood. [`minimatch.match` supports both a string and an array of patterns](https://github.com/isaacs/minimatch#minimatchmatchlist-pattern-options) thus we should accept both in the plugin's `include` and `exclude` options, e.g:

```ts
{
  plugins: [
    thyseus({
      include: ['./example/**', './src/**'],
    }),
  ]
}
```

See also: https://rollupjs.org/plugin-development/#transformers