### PR TITLE
[thyseus] [plugins] Permit async plugins

### DIFF
--- a/.changeset/nervous-humans-type.md
+++ b/.changeset/nervous-humans-type.md
@@ -1,0 +1,5 @@
+---
+'thyseus': patch
+---
+
+Permit async plugins, await promises before building system parameters

--- a/packages/thyseus/src/world/Plugin.ts
+++ b/packages/thyseus/src/world/Plugin.ts
@@ -3,4 +3,6 @@ import { World } from './World';
 /**
  * A function that takes a world and may add event listeners, systems, and data to it.
  */
-export type Plugin = (world: World) => void;
+export type Plugin =
+	| ((world: World) => Promise<void>)
+	| ((world: World) => void);


### PR DESCRIPTION
Resolves #58

Adds async plugins, more or less using the method described in the ticket. When `World.p.prepare()` is called async plugin promises will be resolved before systems are built.