### PR TITLE
[thyseus] [queries] Query iterator methods

### DIFF
--- a/.changeset/tiny-dryers-wonder.md
+++ b/.changeset/tiny-dryers-wonder.md
@@ -1,0 +1,5 @@
+---
+'thyseus': patch
+---
+
+Add forEach and reduce methods to queries

--- a/packages/thyseus/src/queries/Query.ts
+++ b/packages/thyseus/src/queries/Query.ts
@@ -59,6 +59,17 @@ export class Query<A extends object | object[], F extends Filter = Filter> {
 	}
 
 	/**
+	 * Calls the provided callback function for all entities in the query.
+	 * @param callback The callback to be called for all entities in this query.
+	 */
+	forEach(callback: (args: A, index: number) => void) {
+		let index = 0;
+		for (const result of this) {
+			callback(result, index++);
+		}
+	}
+
+	/**
 	 * Calls the provided callback function for all the entities in the query.
 	 * The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
 	 * @param callback The callback to be called for every entity in the query.

--- a/packages/thyseus/src/queries/Query.ts
+++ b/packages/thyseus/src/queries/Query.ts
@@ -58,6 +58,29 @@ export class Query<A extends object | object[], F extends Filter = Filter> {
 		return result;
 	}
 
+	*[Symbol.iterator](): Iterator<A> {
+		const elements = [];
+		const componentCount = this.#components.length;
+		for (
+			let columnGroup = 0;
+			columnGroup < this.#columns.length;
+			columnGroup += componentCount
+		) {
+			const { length } = this.#columns[columnGroup];
+			for (let iterations = 0; iterations < length; iterations++) {
+				for (
+					let columnOffset = 0;
+					columnOffset < componentCount;
+					columnOffset++
+				) {
+					elements[columnOffset] =
+						this.#columns[columnGroup + columnOffset][iterations];
+				}
+				yield (this.#isIndividual ? elements[0] : elements) as any;
+			}
+		}
+	}
+
 	/**
 	 * Calls the provided callback function for all entities in the query.
 	 * @param callback The callback to be called for all entities in this query.
@@ -106,29 +129,6 @@ export class Query<A extends object | object[], F extends Filter = Filter> {
 			}
 		}
 		return initialValue;
-	}
-
-	*[Symbol.iterator](): Iterator<A> {
-		const elements = [];
-		const componentCount = this.#components.length;
-		for (
-			let columnGroup = 0;
-			columnGroup < this.#columns.length;
-			columnGroup += componentCount
-		) {
-			const { length } = this.#columns[columnGroup];
-			for (let iterations = 0; iterations < length; iterations++) {
-				for (
-					let columnOffset = 0;
-					columnOffset < componentCount;
-					columnOffset++
-				) {
-					elements[columnOffset] =
-						this.#columns[columnGroup + columnOffset][iterations];
-				}
-				yield (this.#isIndividual ? elements[0] : elements) as any;
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
Resolves #76

Opted not to go for `.map()` as it doesn't make as much sense on iterators. A lot of these will thankfully be removeable once TC39 iterator proposal happens